### PR TITLE
Fixed VS2015 error; snprintf std is now included

### DIFF
--- a/build/win32/config.h
+++ b/build/win32/config.h
@@ -94,5 +94,7 @@
 #define inline __inline
 #endif
 #define strcasecmp stricmp
-#define snprintf _snprintf
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif


### PR DESCRIPTION
Visual Studio's compiler (C++ 14) now includes a standard library version of snprintf