### PR TITLE
slang driver: enable utf8 auto-detection

### DIFF
--- a/caca/driver/slang.c
+++ b/caca/driver/slang.c
@@ -178,6 +178,7 @@ static int slang_init_graphics(caca_display_t *dp)
 #endif
 
 #ifdef HAVE_SLSMG_UTF8_ENABLE
+    SLutf8_enable(-1);    /* execute utf8 autodetection */
     SLsmg_utf8_enable(1); /* 1 == force, 0 == disable, -1 == autodetect */
     SLtt_utf8_enable(-1);
 #endif


### PR DESCRIPTION
The slang internal auto-detection of utf8 is only executed by a call to
SLutf8_enable(-1).  But this is currently missing.  Hence "auto-detection"
in SLtt_utf8_enable(-1) will always fail.