### PR TITLE
Bold/italic attribute support for export to svg

### DIFF
--- a/caca/codec/export.c
+++ b/caca/codec/export.c
@@ -888,10 +888,13 @@ static void *export_svg(caca_canvas_t const *cv, size_t *bytes)
                 continue;
             }
 
-            cur += sprintf(cur, "<text style=\"fill:#%.03x\" "
+            cur += sprintf(cur, "<text style=\"fill:#%.03x\"%s%s "
                                 "x=\"%d\" y=\"%d\">",
-                                caca_attr_to_rgb12_fg(*lineattr++),
+                                caca_attr_to_rgb12_fg(*lineattr),
+                                (*lineattr & CACA_BOLD) ? " font-weight=\"bold\"" : "",
+                                (*lineattr & CACA_ITALICS) ? " font-style=\"italic\"" : "",
                                 x * 6, (y * 10) + 8);
+            lineattr++;
 
             if(ch < 0x00000020)
                 *cur++ = '?';


### PR DESCRIPTION
Simple change to enable bold & italic attributes for export to SVG.

(I think the buffer size is still large enough but you might want to check that.)