### PR TITLE
Fix undefined reference to `_caca_alloc2d`

### DIFF
--- a/caca/caca.c
+++ b/caca/caca.c
@@ -284,7 +284,7 @@ char const * caca_get_version(void)
  * XXX: The following functions are private.
  */
 
-extern void *_caca_alloc2d(size_t width, size_t height, size_t elem_size)
+void *_caca_alloc2d(size_t width, size_t height, size_t elem_size)
 {
     if (width == 0 || height == 0 || elem_size == 0 || SIZE_MAX / width / height < elem_size)
         return NULL;

--- a/caca/caca_internals.h
+++ b/caca/caca_internals.h
@@ -268,7 +268,7 @@ extern int _caca_pop_event(caca_display_t *, caca_privevent_t *);
 extern void _caca_set_term_title(char const *);
 
 /* Internal memory function */
-extern void *_caca_alloc2d(size_t width, size_t height, size_t elem_size);
+__extern void *_caca_alloc2d(size_t width, size_t height, size_t elem_size);
 
 /* Profiling functions */
 #if defined PROF

--- a/src/common-image.c
+++ b/src/common-image.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "caca.h"
+#include "caca_internals.h"
 
 #include "common-image.h"
 


### PR DESCRIPTION
- Avoid implicit function declaration for `_caca_alloc2d`
- Avoid nested extern declaration for `_caca_alloc2d`
- Fix undefined reference to `_caca_alloc2d`

Fixes #59.