### PR TITLE
misc fixes to allow build in Windows UWP builds

### DIFF
--- a/caca/canvas.c
+++ b/caca/canvas.c
@@ -27,6 +27,10 @@
 #       include <unistd.h>
 #   endif
 #endif
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 #include "caca.h"
 #include "caca_internals.h"
@@ -351,7 +355,11 @@ int caca_rand(int min, int max)
 
     if(need_init)
     {
+#ifdef _WIN32
+        srand(GetCurrentProcessId() + _caca_getticks(&timer));
+#else
         srand(getpid() + _caca_getticks(&timer));
+#endif
         need_init = 0;
     }
 

--- a/caca/driver/win32.c
+++ b/caca/driver/win32.c
@@ -25,7 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
 /* This is missing from the MinGW headers. */
 #   if (_WIN32_WINNT >= 0x0500)
 BOOL WINAPI GetCurrentConsoleFont(HANDLE hConsoleOutput, BOOL bMaximumWindow,

--- a/caca/driver/win32.c
+++ b/caca/driver/win32.c
@@ -196,7 +196,7 @@ static int win32_end_graphics(caca_display_t *dp)
 
 static int win32_set_display_title(caca_display_t *dp, char const *title)
 {
-    SetConsoleTitle(title);
+    SetConsoleTitleA(title);
     return 0;
 }
 

--- a/caca/driver/win32.c
+++ b/caca/driver/win32.c
@@ -19,7 +19,9 @@
 
 #if defined(USE_WIN32)
 
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x500 /* _WIN32_WINNT_WIN2K */
 #define _WIN32_WINNT 0x500 /* Require WinXP or later */
+#endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 


### PR DESCRIPTION
UWP stands for Universal Windows Platform. The API is restricted, some calls are forbidden. But we can replace them by equivalent ones.