### PR TITLE
Disable LTO when checking for fsin/fcos/fldln2/...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,9 @@ AC_COMPILE_IFELSE(
   AC_DEFINE(HAVE_SLEEP, 1, [Define to 1 if you have the ‘Sleep’ function.])],
  [AC_MSG_RESULT(no)])
 
+# Disable LTO when checking for the instructions
+CFLAGS="${CFLAGS} -fno-lto"
+
 AC_MSG_CHECKING(for fsin/fcos)
 AC_COMPILE_IFELSE(
  [AC_LANG_PROGRAM(
@@ -162,6 +165,8 @@ AC_COMPILE_IFELSE(
  [AC_MSG_RESULT(yes)
   AC_DEFINE(HAVE_FLDLN2, 1, [Define to 1 if you have the ‘fldln2’ and other floating point instructions.])],
  [AC_MSG_RESULT(no)])
+
+CFLAGS="${CFLAGS%$' -fno-lto'}"
 
 AC_CHECK_HEADERS(zlib.h)
 AC_CHECK_LIB(z, gzopen, [ZLIB_LIBS="${ZLIB_LIBS} -lz"])


### PR DESCRIPTION
LTO might interfere with the instruction detection and produce false positives. (The conftest.c compiles with `-flto=auto` but fails without it)

The build for riscv64 arch linux fails because of this: https://archriscv.felixc.at/.status/log.htm?url=logs/libcaca/libcaca-0.99.beta20-2.log

This PR fixes it.